### PR TITLE
Allow JWTs signed with RS256 asymmetric keys.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: erlang
+otp_release:
+  - 18.2.1
+sudo: false
+addons:
+  apt:
+    packages:
+    - cmake
+    - time
+script: rebar co eunit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # couch_jwt_auth
 
+[![Build Status](https://travis-ci.org/dmunch/couch_jwt_auth.svg?branch=master)](https://travis-ci.org/dmunch/couch_jwt_auth)
+
 couch_jwt_auth is authentication plugin for CouchDB. It accepts JSON Web Token in the Authorization
 HTTP header and creates CouchDB user context from the token information. couch_jwt_auth doesn't use
 CouchDB authentication database. User roles are read directly from JWT and not from the

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]}.
 {clean_files, ["*.eunit", "ebin/*.beam"]}.
 {deps, [
-    {jose, ".*", {git, "git://github.com/potatosalad/erlang-jose.git", {branch, "master"}}},
-    {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {branch, "master"}}},
+    {jose, ".*", {git, "git://github.com/potatosalad/erlang-jose.git", {tag, "1.7.3"}}},
+    {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "2.8.0"}}},
     {meck, ".*", {git, "https://github.com/eproxus/meck.git", {tag, "0.8.3"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]}.
 {clean_files, ["*.eunit", "ebin/*.beam"]}.
 {deps, [
-    {jose, ".*", {git, "git://github.com/potatosalad/erlang-jose.git", {tag, "1.7.3"}}},
+    {jose, ".*", {git, "git://github.com/potatosalad/erlang-jose.git", {tag, "1.8.0"}}},
     {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "2.8.0"}}},
-    {meck, ".*", {git, "https://github.com/eproxus/meck.git", {tag, "0.8.3"}}}
+    {meck, ".*", {git, "https://github.com/eproxus/meck.git", {tag, "0.8.4"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -5,5 +5,6 @@
 {clean_files, ["*.eunit", "ebin/*.beam"]}.
 {deps, [
     {jose, ".*", {git, "git://github.com/potatosalad/erlang-jose.git", {branch, "master"}}},
-    {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {branch, "master"}}}
+    {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {branch, "master"}}},
+    {meck, ".*", {git, "https://github.com/eproxus/meck.git", {tag, "0.8.3"}}}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,5 +4,6 @@
 {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]}.
 {clean_files, ["*.eunit", "ebin/*.beam"]}.
 {deps, [
-    {ejwt, ".*", {git, "https://github.com/artefactop/ejwt"}}
+    {jose, ".*", {git, "git://github.com/potatosalad/erlang-jose.git", {branch, "master"}}},
+    {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {branch, "master"}}}
 ]}.

--- a/src/couch_jwt_auth.erl
+++ b/src/couch_jwt_auth.erl
@@ -221,7 +221,17 @@ decode_rs256_test() ->
   %compare maps here since we don't care about the order of the keys
   ?assertEqual(maps:from_list(TokenInfo), maps:from_list(decode("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE", ?RS256Config))).
 
-validate_simple_test() ->
+decode_rs256_speed_when_loading_jwk_on_each_decoding_test_() ->
+  {timeout, 20, fun() -> lists:map(fun(_) -> 
+                {JWK, Alg} = init_jwk_from_config(?RS256Config),
+                decode("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE", JWK, Alg, ?RS256Config) end, lists:seq(1, 10000)) end}.
+
+decode_rs256_speed_when_using_gen_server_state_test_() ->
+  {timeout, 20, fun() ->
+                    init_jwk(?RS256Config),
+                    lists:map(fun(_) -> decode("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE") end, lists:seq(1, 10000)) end}.
+
+  validate_simple_test() ->
   TokenInfo = ?BasicTokenInfo,
   ?assertEqual(TokenInfo, validate(TokenInfo, 1000, ?EmptyConfig)).
 

--- a/src/couch_jwt_auth.erl
+++ b/src/couch_jwt_auth.erl
@@ -20,6 +20,7 @@
 
 -export([jwt_authentication_handler/1]).
 -export([decode/1]).
+-export([decode/2]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/couch_jwt_auth.erl
+++ b/src/couch_jwt_auth.erl
@@ -108,11 +108,11 @@ init_jwk_from_config(Config) ->
                    OpenIdAuthority -> 
                      ConfigUri = OpenIdAuthority ++ ".well-known/openid-configuration",
                      ?LOG_INFO("Loading public key from  ~s", [ConfigUri]),
-                     Key = openid_connect_configuration:load_jwk_from_config_url(ConfigUri),
-                     case Key of
-                       {jose_jwk, _, _, #{<<"kid">> := Kid}} -> #{Kid => Key};
-                       {jose_jwk, _, _, _} -> #{default => Key}
-                     end
+                     KeySet = openid_connect_configuration:load_jwk_set_from_config_url(ConfigUri),
+                     maps:from_list(lists:map(fun(Key) ->  case Key of
+                       {jose_jwk, _, _, #{<<"kid">> := Kid}} -> {Kid, Key};
+                       {jose_jwk, _, _, _} -> {default, Key}
+                     end end, KeySet))
                  end,
   
   #{hs256 => HsKeys, rs256 => maps:merge(RsPEMKey, RSOpenIdKeys)}.

--- a/src/couch_jwt_auth.erl
+++ b/src/couch_jwt_auth.erl
@@ -15,7 +15,7 @@
 -module(couch_jwt_auth).
 -behaviour(gen_server).
 
--export([start_link/0, start_link/1, init/1, handle_call/3, handle_cast/2, handle_info/2,
+-export([start_link/0, start_link/1, stop/0, init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
 -export([jwt_authentication_handler/1]).
@@ -74,10 +74,11 @@ handle_call({init_jwk, Config}, _From, State) ->
      {JWK, Alg} -> {reply, {ok}, {valid_jwk, JWK, Alg, Config}}
    catch
       _:Error -> {reply, {error, Error}, State}
-   end.
+   end;
 
-handle_cast(stop, State) ->
-    {stop, normal, State};
+handle_call(stop, _From, State) ->
+    {stop, normal, ok, State}.
+
 handle_cast(_Msg, State) ->
     {noreply, State}.
 handle_info(_Msg, State) ->
@@ -125,6 +126,9 @@ init_jwk(Config) ->
     {ok} -> ok;
     {error, Error} -> throw(Error)
   end.
+
+stop() ->
+  gen_server:call(?MODULE, stop).
 
 % Config is list of key value pairs:
 % [{"hs_secret","..."},{"roles_claim","roles"},{"username_claim","sub"}]

--- a/src/couch_jwt_auth.erl
+++ b/src/couch_jwt_auth.erl
@@ -99,6 +99,7 @@ terminate(_Reason, _State) ->
     ok.
 
 init_jwk_from_config(Config) ->
+  jose:json_module(jsx),
   HsKeys = case couch_util:get_value("hs_secret", Config, nil) of
              nil -> #{};
              HsSecret -> #{default => 
@@ -148,10 +149,10 @@ decode(Token, JWK, Alg, Config) ->
 decode(Token) ->
   try jose_jwt:peek_protected(list_to_binary(Token)) of
     TokenProtected -> case TokenProtected of
-                        {jose_jws, {jose_jws_alg_hmac, {jose_jws_alg_hmac, sha256}}, _, #{<<"kid">> := Kid}} -> decode(Token, hs256, Kid);
-                        {jose_jws, {jose_jws_alg_hmac, {jose_jws_alg_hmac, sha256}}, _, _} -> decode(Token, hs256, default);
-                        {jose_jws, {jose_jws_alg_rsa_pkcs1_v1_5, {jose_jws_alg_rsa_pkcs1_v1_5, sha256}}, _, #{<<"kid">> := Kid}} -> decode(Token, rs256, Kid); 
-                        {jose_jws, {jose_jws_alg_rsa_pkcs1_v1_5, {jose_jws_alg_rsa_pkcs1_v1_5, sha256}}, _, _} -> decode(Token, rs256, default);
+                        {jose_jws, {jose_jws_alg_hmac, 'HS256'}, _, #{<<"kid">> := Kid}} -> decode(Token, hs256, Kid);
+                        {jose_jws, {jose_jws_alg_hmac, 'HS256'}, _, _} -> decode(Token, hs256, default);
+                        {jose_jws, {jose_jws_alg_rsa_pkcs1_v1_5, 'RS256'}, _, #{<<"kid">> := Kid ,<<"typ">> := <<"JWT">>}} -> decode(Token, rs256, Kid); 
+                        {jose_jws, {jose_jws_alg_rsa_pkcs1_v1_5, 'RS256'}, _, _} -> decode(Token, rs256, default);
                         _ -> throw(signature_not_valid)
                       end
   catch

--- a/src/couch_jwt_auth.erl
+++ b/src/couch_jwt_auth.erl
@@ -188,6 +188,7 @@ get_userinfo_from_token(User, Config) ->
 MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDdlatRjRjogo3WojgGHFHYLugdUWAY9iR3fy4arWNA1KoS8kVw33cJibXr8bvwUAUparCwlvdbH6dvEOfou0/gCFQsHUfQrSDv+MuSUMAe8jzKE4qW+jK+xQU9a03GUnKHkkle+Q0pX/g6jXZ7r1/xAK5Do2kQ+X5xK9cipRgEKwIDAQAB
 -----END PUBLIC KEY-----"}]).
 -define (RS256TokenInfo, [{"sub",<<"1234567890">>},{"name",<<"John Doe">>},{"admin",true}]).
+-define (RS256Token, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE").
 
 init_jwk_from_config_nil_test() ->
   ?assertThrow(no_token_secret_given, init_jwk_from_config(?NilConfig)).
@@ -219,17 +220,17 @@ decode_unsecured_test() ->
 decode_rs256_test() ->
   TokenInfo = ?RS256TokenInfo,
   %compare maps here since we don't care about the order of the keys
-  ?assertEqual(maps:from_list(TokenInfo), maps:from_list(decode("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE", ?RS256Config))).
+  ?assertEqual(maps:from_list(TokenInfo), maps:from_list(decode(?RS256Token, ?RS256Config))).
 
 decode_rs256_speed_when_loading_jwk_on_each_decoding_test_() ->
   {timeout, 20, fun() -> lists:map(fun(_) -> 
                 {JWK, Alg} = init_jwk_from_config(?RS256Config),
-                decode("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE", JWK, Alg, ?RS256Config) end, lists:seq(1, 10000)) end}.
+                decode(?RS256Token, JWK, Alg, ?RS256Config) end, lists:seq(1, 10000)) end}.
 
 decode_rs256_speed_when_using_gen_server_state_test_() ->
   {timeout, 20, fun() ->
                     init_jwk(?RS256Config),
-                    lists:map(fun(_) -> decode("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE") end, lists:seq(1, 10000)) end}.
+                    lists:map(fun(_) -> decode(?RS256Token) end, lists:seq(1, 1000)) end}.
 
   validate_simple_test() ->
   TokenInfo = ?BasicTokenInfo,

--- a/src/couch_jwt_auth.erl
+++ b/src/couch_jwt_auth.erl
@@ -15,16 +15,19 @@
 -module(couch_jwt_auth).
 -behaviour(gen_server).
 
--export([start_link/0, init/1, handle_call/3, handle_cast/2, handle_info/2,
+-export([start_link/0, start_link/1, init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
 -export([jwt_authentication_handler/1]).
+-export([init_jwk_from_config/1]).
+-export([init_jwk/1]).
 -export([decode/1]).
 -export([decode/2]).
+-export([decode/4]).
+-export([validate/3]).
 
--ifdef(TEST).
--include_lib("eunit/include/eunit.hrl").
--endif.
+-export([posix_time/1]).
+-export([get_userinfo_from_token/2]).
 
 -include_lib("couch/include/couch_db.hrl").
 
@@ -170,140 +173,3 @@ get_userinfo_from_token(User, Config) ->
   UserName = couch_util:get_value(couch_util:get_value("username_claim", Config, "sub"), User, null),
   Roles = couch_util:get_value(couch_util:get_value("roles_claim", Config, "roles"), User, []),
   {UserName, Roles}.
-
-
-
-% UNIT TESTS
--ifdef(TEST).
-
--define (NilConfig, []).
--define (EmptyConfig, [{"hs_secret",""}]).
--define (BasicConfig, [{"hs_secret","c2VjcmV0"}]).
--define (ConflictingConfig, [{"hs_secret","c2VjcmV0"}, {"rs_public_key", ".."}]).
--define (BasicTokenInfo, [{"sub",<<"1234567890">>},{"name",<<"John Doe">>},{"admin",true}]).
--define (RS256Config, [{"rs_public_key","-----BEGIN PUBLIC KEY-----
-MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDdlatRjRjogo3WojgGHFHYLugdUWAY9iR3fy4arWNA1KoS8kVw33cJibXr8bvwUAUparCwlvdbH6dvEOfou0/gCFQsHUfQrSDv+MuSUMAe8jzKE4qW+jK+xQU9a03GUnKHkkle+Q0pX/g6jXZ7r1/xAK5Do2kQ+X5xK9cipRgEKwIDAQAB
------END PUBLIC KEY-----"}]).
--define (RS256TokenInfo, [{"sub",<<"1234567890">>},{"name",<<"John Doe">>},{"admin",true}]).
--define (RS256Token, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE").
-
-init_jwk_from_config_nil_test() ->
-  ?assertThrow(no_token_secret_given, init_jwk_from_config(?NilConfig)).
-
-init_jwk_conflicting_config_test() ->
-  ?assertThrow(hs_and_rs_configuration_conflict, init_jwk_from_config(?ConflictingConfig)).
-
-decode_malformed_empty_test() ->
-  start_link(?EmptyConfig),
-  ?assertThrow({badarg,_}, decode("", ?EmptyConfig)).
-
-decode_malformed_dots_test() ->
-  ?assertThrow({badarg,_}, decode("...", ?EmptyConfig)).
-
-decode_malformed_nosignature1_test() ->
-  ?assertThrow({badarg,_}, decode("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOmZhbHNlfQ", ?BasicConfig)).
-
-decode_malformed_nosignature2_test() ->
-  ?assertThrow(signature_not_valid, decode("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOmZhbHNlfQ.", ?BasicConfig)).
-
-decode_simple_test() ->
-  TokenInfo = ?BasicTokenInfo,
-  %compare maps here since we don't care about the order of the keys
-  ?assertEqual(maps:from_list(TokenInfo), maps:from_list(decode("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ", ?BasicConfig))).
-
-decode_unsecured_test() ->
-  ?assertThrow(signature_not_valid, decode("eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.", ?BasicConfig)).
-
-decode_rs256_test() ->
-  TokenInfo = ?RS256TokenInfo,
-  %compare maps here since we don't care about the order of the keys
-  ?assertEqual(maps:from_list(TokenInfo), maps:from_list(decode(?RS256Token, ?RS256Config))).
-
-decode_rs256_speed_when_loading_jwk_on_each_decoding_test_handler() -> 
-  lists:map(fun(_) -> 
-                {JWK, Alg} = init_jwk_from_config(?RS256Config),
-                decode(?RS256Token, JWK, Alg, ?RS256Config) end, lists:seq(1, 10000)).
-
-decode_rs256_speed_when_loading_jwk_on_each_decoding_test_() ->
-  {timeout, 20, fun decode_rs256_speed_when_loading_jwk_on_each_decoding_test_handler/0}.
-
-decode_rs256_speed_when_loading_jwk_on_each_decoding_parallel_test_() ->
-  {inparallel, [{timeout, 20, fun decode_rs256_speed_when_loading_jwk_on_each_decoding_test_handler/0}, 
-                {timeout, 20, fun decode_rs256_speed_when_loading_jwk_on_each_decoding_test_handler/0},
-                {timeout, 20, fun decode_rs256_speed_when_loading_jwk_on_each_decoding_test_handler/0}]}.
-
-decode_rs256_speed_when_using_gen_server_state_test_handler() ->
-  init_jwk(?RS256Config),
-  lists:map(fun(_) -> decode(?RS256Token) end, lists:seq(1, 10000)).
-
-decode_rs256_speed_when_using_gen_server_state_test_() ->
-  {timeout, 20, fun decode_rs256_speed_when_using_gen_server_state_test_handler/0}.
-
-decode_rs256_speed_when_using_gen_server_state_parallel_test_() ->
-  {inparallel, [{timeout, 20, fun decode_rs256_speed_when_using_gen_server_state_test_handler/0}, 
-                {timeout, 20, fun decode_rs256_speed_when_using_gen_server_state_test_handler/0}, 
-                {timeout, 20, fun decode_rs256_speed_when_using_gen_server_state_test_handler/0}]}.
-
-validate_simple_test() ->
-  TokenInfo = ?BasicTokenInfo,
-  ?assertEqual(TokenInfo, validate(TokenInfo, 1000, ?EmptyConfig)).
-
-validate_exp_nbf_test() ->
-  TokenInfo = lists:append([?BasicTokenInfo,[{"exp",2000}, {"nbf",900}]]),
-  ?assertEqual(TokenInfo, validate(TokenInfo, 1000, ?EmptyConfig)).
-
-validate_exp_rejected_test() ->
-  TokenInfo = lists:append([?BasicTokenInfo,[{"exp",2000}]]),
-  ?assertThrow(token_rejected, validate(TokenInfo, 3000, ?EmptyConfig)).
-
-validate_nbf_rejected_test() ->
-  TokenInfo = lists:append([?BasicTokenInfo,[{"nbf",2000}, {"exp",3000}]]),
-  ?assertThrow(token_rejected, validate(TokenInfo, 1000, ?EmptyConfig)).
-
-validate_aud1_rejected_test() ->
-  TokenInfo = lists:append([?BasicTokenInfo,[{"aud",<<"123">>}]]),
-  Config = lists:append([?EmptyConfig, [{"validated_claims", "aud"}, {"validate_claim_aud", "[\"456\"]"}]]),
-  ?assertThrow(token_rejected, validate(TokenInfo, 1000, Config)).
-
-validate_aud2_rejected_test() ->
-  TokenInfo = lists:append([?BasicTokenInfo,[{"aud",[<<"123">>,<<"234">>]}]]),
-  Config = lists:append([?EmptyConfig, [{"validated_claims", "aud"}, {"validate_claim_aud", "[\"456\"]"}]]),
-  ?assertThrow(token_rejected, validate(TokenInfo, 1000, Config)).
-
-validate_aud_pass_test() ->
-  TokenInfo = lists:append([?BasicTokenInfo,[{"aud",[<<"123">>,<<"234">>]}]]),
-  Config = lists:append([?EmptyConfig, [{"validated_claims", "aud"}, {"validate_claim_aud", "[\"123\",\"456\"]"}]]),
-  ?assertEqual(TokenInfo, validate(TokenInfo, 1000, Config)).
-
-validate_claims_pass_test() ->
-  TokenInfo = lists:append([?BasicTokenInfo,[{"aud",<<"123">>}, {"iss",<<"abc">>}]]),
-  Config = lists:append([?EmptyConfig, [{"validated_claims", "aud,iss"}, {"validate_claim_aud", "[\"123\"]"},{"validate_claim_iss", "[\"abc\"]"}]]),
-  ?assertEqual(TokenInfo, validate(TokenInfo, 1000, Config)).
-
-posix_time1_test() ->
-  ?assertEqual(31536000, posix_time({{1971,1,1}, {0,0,0}})).
-
-posix_time2_test() ->
-  ?assertEqual(31536001, posix_time({{1971,1,1}, {0,0,1}})).
-
-get_userinfo_from_token_default_test() ->
-  TokenInfo = ?BasicTokenInfo,
-  {UserName, Roles} = get_userinfo_from_token(TokenInfo, ?EmptyConfig),
-  ?assertEqual([], Roles),
-  ?assertEqual(<<"1234567890">>, UserName).
-
-get_userinfo_from_token_configured_test() ->
-  TokenInfo = ?BasicTokenInfo,
-  Config = lists:append([?EmptyConfig, [{"username_claim", "name"}]]),
-  {UserName, Roles} = get_userinfo_from_token(TokenInfo, Config),
-  ?assertEqual([], Roles),
-  ?assertEqual(<<"John Doe">>, UserName).
-
-% user context is created with null username if username claim is not found from token
-get_userinfo_from_token_name_not_found_test() ->
-  TokenInfo = lists:append([?BasicTokenInfo,[{"roles",[<<"123">>]}]]),
-  Config = lists:append([?EmptyConfig, [{"username_claim", "doesntexist"}]]),
-  {UserName, Roles} = get_userinfo_from_token(TokenInfo, Config),
-  ?assertEqual([<<"123">>], Roles),
-  ?assertEqual(null, UserName).
--endif.

--- a/src/couch_jwt_auth.erl
+++ b/src/couch_jwt_auth.erl
@@ -35,9 +35,9 @@
 -ifndef(LOG_INFO).
 %we're most certainly compiling for CouchDB 2.0
 -define(LOG_INFO(Format, Args), couch_log:info(Format, Args)).
--define(CONFIG_GET(Section), couch_config:get(Section)).
--else.
 -define(CONFIG_GET(Section), config:get(Section)).
+-else.
+-define(CONFIG_GET(Section), couch_config:get(Section)).
 -endif.
 
 -ifndef(JSON_DECODE).

--- a/src/openid_connect_configuration.erl
+++ b/src/openid_connect_configuration.erl
@@ -1,0 +1,48 @@
+-module(openid_connect_configuration).
+-export([load_jwk_from_config_url/1]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+load_jwk_from_config_url(ConfigurationUrl) -> 
+  {ok, { {_, 200, _}, _, ConfigurationJson}} = httpc:request(ConfigurationUrl),
+  Configuration = jsx:decode(list_to_binary(ConfigurationJson), [return_maps]),
+  #{<<"jwks_uri">> := JwksUri} = Configuration,
+  {ok, { {_, 200, _}, _, JwksJson}} = httpc:request(binary_to_list(JwksUri)),
+  jose_jwk:from(list_to_binary(JwksJson)).
+
+
+% UNIT TESTS
+-ifdef(TEST).
+
+%Set of Google keys as of April 30 2016.
+%Quick and dirty approach to testing, test will fail once Google change their keys. 
+-define (GoogleJwk, {jose_jwk,{jose_jwk_set,[{jose_jwk,undefined,
+                                              {jose_jwk_kty_rsa,{'RSAPublicKey',20206560680338767966113549800092864444815226395364321118810492063125077232472726130026157875619038715958927265601322339310166323162412293093211851469723779575522576466296478566790747995780410098571744471878323937448645573393799654878349438130854284659811893569111373873227493475199456374892951853689365519614169586464843255523436575946022077125295883638933581666742449113039099591769210025714286073302286758273862925269047851682708672135770642709064117060149558805245180906038583088131620476785661270604325423755298411912486722600991370383679800980249390767569969763750539090229703190168094445793264267808336779990059,
+                                                                 65537}},
+                                              #{<<"alg">> => <<"RS256">>,
+                                                <<"kid">> => <<"225038926437474586a7bcd302b06694e9d70733">>,
+                                                <<"use">> => <<"sig">>}},
+                                             {jose_jwk,undefined,
+                                              {jose_jwk_kty_rsa,{'RSAPublicKey',23057364752339592387136431039591833247815320249115920080891100289620278805852536284027635618114699005339098620472360194835114382896398817355924696759257721908424490779772199553649363807728476991453601444338567461874061798086043217971021947782206212438615786452801531112195267535798912116270886899785585331030698336380098736448360775545570371716003476414126501361187359607038623392527667825820035625377025785657841602136549202456722129978768350261691227033539821412280231303717786830482708766431502430886533945121478791201757452016728731956367280993909631426542805588267882542261363135351403804590666438077263901561561,
+                                                                 65537}},
+                                              #{<<"alg">> => <<"RS256">>,
+                                                <<"kid">> => <<"0c0e73cd83b43b1243bb05eccbf4f2908416d1d4">>,
+                                                <<"use">> => <<"sig">>}}]},
+                     undefined,#{}}).
+
+load_jwk_from_config_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+      {"should load jwk from google openid configuration", fun() -> 
+                                                               ?assertEqual(?GoogleJwk, load_jwk_from_config_url("https://accounts.google.com/.well-known/openid-configuration")) end} 
+    ]}.
+
+setup() ->
+  {ok, _} = application:ensure_all_started(inets),
+  {ok, _} = application:ensure_all_started(ssl).
+
+cleanup(_) ->
+  ok.
+
+-endif.

--- a/src/openid_connect_configuration.erl
+++ b/src/openid_connect_configuration.erl
@@ -1,22 +1,19 @@
 -module(openid_connect_configuration).
--export([load_jwk_from_config_url/1]).
+-export([load_jwk_set_from_config_url/1]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
-load_jwk_from_config_url(ConfigurationUrl) -> 
+load_jwk_set_from_config_url(ConfigurationUrl) -> 
   {ok, { {_, 200, _}, _, ConfigurationJson}} = httpc:request(ConfigurationUrl),
   Configuration = jsx:decode(list_to_binary(ConfigurationJson), [return_maps]),
   #{<<"jwks_uri">> := JwksUri} = Configuration,
   {ok, { {_, 200, _}, _, JwksJson}} = httpc:request(binary_to_list(JwksUri)),
   case Jwk = jose_jwk:from(list_to_binary(JwksJson)) of
-	{jose_jwk, undefined, _, _} -> Jwk;%single key
-	{jose_jwk, {jose_jwk_set, KeySet}, _, _} -> 
-		  %key set, take first key
-		  [FirstKey | _] = KeySet,
-		  FirstKey
-	end.
+    {jose_jwk, {jose_jwk_set, KeySet}, _, _} -> KeySet; 
+    {jose_jwk, undefined, _, _} -> [Jwk]%single key
+  end.
 
 
 % UNIT TESTS
@@ -28,16 +25,34 @@ Qx51AhEAz6VUgN0H5+1xwyOBtq/YEQIRANO6cLLvOFBNNaG9igT3ma0CEQClL7lR
 6oRnlRVzT8PZOXqBAhEAssLyiaIABERKr2aGrKyE9A==
 -----END RSA PRIVATE KEY-----").
 
--define (KeySetJson, "{'keys':[{'kid':'HCVGNTNQFL1IA56BHLSPMMTZ8UHXXUO_9UNZ3UAO','use':'sig','kty':'RSA','alg':'RS256','e':'EQ','n':'hcVgNTNQFL1Ia56bhlSPmmTZ8UhXxUO_9UNZ3uAOdh6jOpXczGJFLSK8SuOnm4JuiTcC5gsqf6uMgwJl-TywWVo_GC026MzfCu4NOaKmVx7p3Hs4DzXqaAQwv9Q6sFzF50QK-uMrdStS2Mqd_eT-dtXN2-dT9CQZfP_vHVl6UBAuUiocts5ielHo95FTnLMVC9TEOyCKnQ_u_335p5LEhgTvhXPPO7EV7H8cVGmAOl7Z_2qS2LwS6MKJaQJmMybM3YGVrz-TGJKg-5qCBOzcevsdjgyJlUuKpgzMKuxAC4lFSvuMeCD1ml-zRNsGrcCMyfbIa4xkIwPMvaf_ZfCzaw'}]}").
-
--define (PEMKeyInKeySet, "-----BEGIN RSA PUBLIC KEY-----
-MIIBCAKCAQEAhcVgNTNQFL1Ia56bhlSPmmTZ8UhXxUO/9UNZ3uAOdh6jOpXczGJF
-LSK8SuOnm4JuiTcC5gsqf6uMgwJl+TywWVo/GC026MzfCu4NOaKmVx7p3Hs4DzXq
-aAQwv9Q6sFzF50QK+uMrdStS2Mqd/eT+dtXN2+dT9CQZfP/vHVl6UBAuUiocts5i
-elHo95FTnLMVC9TEOyCKnQ/u/335p5LEhgTvhXPPO7EV7H8cVGmAOl7Z/2qS2LwS
-6MKJaQJmMybM3YGVrz+TGJKg+5qCBOzcevsdjgyJlUuKpgzMKuxAC4lFSvuMeCD1
-ml+zRNsGrcCMyfbIa4xkIwPMvaf/ZfCzawIBEQ==
------END RSA PUBLIC KEY-----").
+-define (KeySetJson, "{
+'keys': [
+{
+ 'kty': 'RSA',
+ 'alg': 'RS256',
+ 'use': 'sig',
+ 'kid': '2e4c1fcf6e968282397fe03ab848d4e9c9c27bb3',
+ 'n': 'wD49pRcnhqqvg3elGfH-oP6VSKuaf9ELSYwKSq4pXPwp01lIGtareYLT0gYQw_PXOQLN_ttt8JmvPVwijr3UQ6eCiVhWnFDJFpNlaYOyCfpKEJU0q25ZiPkbQYnG1cpM9Um1YjaB7at_pdBFdkMfO0H7yHVyypmfdcHQRdMN_AdeIwfsYnR3sk83I0JzT_DB28n6YlHfsk8tfF7MIRZ6TZbhIJf_3n_RnV-i6ymY6r_818Zv9gnhYRjadVGT0vvXE0lIWTRDcYuBhlLF_Uhi_KVUr6pMVhjVFvswBh2ixAL3Aet-OK8qQj13OhC9bBVVz7lAarLhhxyG5UMdHWhIhw',
+ 'e': 'AQAB'
+},
+{
+ 'kty': 'RSA',
+ 'alg': 'RS256',
+ 'use': 'sig',
+ 'kid': '5243b429de18f456856093046740e05664c42996',
+ 'n': '5FZPC-na4vUy-Q9n0yXtMctyf8RqMcU0lAEzGgfFintDXBmMREw3-4K8XcgfpGibyG_05sGTbuVb058FgudfKmHe5rfD-Fy37R4jtpPy1Gnqhw26ytehZPhq5MWjH9sYPaTb1CFd7rZRrArTksk4iceGAyGWX2pvCVE0r5-_UWUoVW289SDqRBrv6MnxD8FYUX5-NGLThM-07AsXHtN04q19_mMKV4TfTwkUlZb-EGa88YKia16HxiVZeRaE2NVpGMJYxd-TizMtACjdd616kSt2ZUNV4Tx1C8HM779yXyu-5kiqO2niQkPnUvSLOWMcJSaE-osVHaqoLrRcEU3ugQ',
+ 'e': 'AQAB'
+},
+{
+ 'kty': 'RSA',
+ 'alg': 'RS256',
+ 'use': 'sig',
+ 'kid': 'f596800f80b253fcd7fa6eb50c0dd60a32cb29ec',
+ 'n': '5gCnR8CDlMunqB5EdXYpFhRBeTXbf-88P7CTN8v7_wPVuuXjhTuP6gnP0BnSI3l4JcYVOP65nvRzkKJVEqP2Wrom1kwQYQBkjLTze_jsYEtTaNocA9anl0OprhVy4DkytEpZ4b3EfYpr4BNxkMTEhefgUmM-HNyDUw-IHaR37tbzopcJ4dnv8K94p1mwnwb78wxLEViGXuOFCe6Nwf6K68idliekUVdQSFUocwVznCi4OffZQcsWP6wtELqBRYqmBvnHAuygZCet7rLwBy-i82f0vGZhpQvnWP8yltgvCqSGJ5J0lS0fJ9e92aD_RBb2HV9LY72z2kIeQ30p9vVOvQ',
+ 'e': 'AQAB'
+}
+]
+}").
 
 %don't use test generator pattern here, otherwise we run into a funny meck issue
 %when trying to mock openid_connect_configuration module lateron:
@@ -53,14 +68,14 @@ load_single_jwk_from_config_test() ->
                                 {ok, { {"Version",200, "Reason"}, [], binary_to_list(JwkJson)}}}
                               ]), 
   try
-    JwkLoaded = load_jwk_from_config_url("http://localhost/.well-known/openid-configuration"),
-    ?assertEqual(PrivateJwk, JwkLoaded)
+    JwkLoaded = load_jwk_set_from_config_url("http://localhost/.well-known/openid-configuration"),
+    ?assertEqual([PrivateJwk], JwkLoaded)
   after
     meck:validate(httpc),
     meck:unload(httpc) 
   end.
 
-load_first_jwk_from_set_from_config_test() ->
+load_jwk_set_from_from_config_test() ->
   meck:new(httpc),
   meck:expect(httpc, request, [{["http://localhost/.well-known/openid-configuration"],
                                 {ok, { {"Version",200, "Reason"}, [], "{'jwks_uri': 'http://localhost/jwks'}"}}},
@@ -68,8 +83,9 @@ load_first_jwk_from_set_from_config_test() ->
                                 {ok, { {"Version",200, "Reason"}, [], ?KeySetJson}}}
                               ]), 
   try
-    JwkLoaded = load_jwk_from_config_url("http://localhost/.well-known/openid-configuration"),
-    ?assertEqual(jose_jwk:to_pem(jose_jwk:from_pem(list_to_binary(?PEMKeyInKeySet))), jose_jwk:to_pem(JwkLoaded))
+    JwkLoaded = load_jwk_set_from_config_url("http://localhost/.well-known/openid-configuration"),
+    {jose_jwk, {jose_jwk_set, KeySet}, _, _} = jose_jwk:from(list_to_binary(?KeySetJson)),
+    ?assertEqual(KeySet, JwkLoaded)
   after
     meck:validate(httpc),
     meck:unload(httpc) 

--- a/src/openid_connect_configuration.erl
+++ b/src/openid_connect_configuration.erl
@@ -10,7 +10,13 @@ load_jwk_from_config_url(ConfigurationUrl) ->
   Configuration = jsx:decode(list_to_binary(ConfigurationJson), [return_maps]),
   #{<<"jwks_uri">> := JwksUri} = Configuration,
   {ok, { {_, 200, _}, _, JwksJson}} = httpc:request(binary_to_list(JwksUri)),
-  jose_jwk:from(list_to_binary(JwksJson)).
+  case Jwk = jose_jwk:from(list_to_binary(JwksJson)) of
+	{jose_jwk, undefined, _, _} -> Jwk;%single key
+	{jose_jwk, {jose_jwk_set, KeySet}, _, _} -> 
+		  %key set, take first key
+		  [FirstKey | _] = KeySet,
+		  FirstKey
+	end.
 
 
 % UNIT TESTS
@@ -22,10 +28,21 @@ Qx51AhEAz6VUgN0H5+1xwyOBtq/YEQIRANO6cLLvOFBNNaG9igT3ma0CEQClL7lR
 6oRnlRVzT8PZOXqBAhEAssLyiaIABERKr2aGrKyE9A==
 -----END RSA PRIVATE KEY-----").
 
+-define (KeySetJson, "{'keys':[{'kid':'HCVGNTNQFL1IA56BHLSPMMTZ8UHXXUO_9UNZ3UAO','use':'sig','kty':'RSA','alg':'RS256','e':'EQ','n':'hcVgNTNQFL1Ia56bhlSPmmTZ8UhXxUO_9UNZ3uAOdh6jOpXczGJFLSK8SuOnm4JuiTcC5gsqf6uMgwJl-TywWVo_GC026MzfCu4NOaKmVx7p3Hs4DzXqaAQwv9Q6sFzF50QK-uMrdStS2Mqd_eT-dtXN2-dT9CQZfP_vHVl6UBAuUiocts5ielHo95FTnLMVC9TEOyCKnQ_u_335p5LEhgTvhXPPO7EV7H8cVGmAOl7Z_2qS2LwS6MKJaQJmMybM3YGVrz-TGJKg-5qCBOzcevsdjgyJlUuKpgzMKuxAC4lFSvuMeCD1ml-zRNsGrcCMyfbIa4xkIwPMvaf_ZfCzaw'}]}").
+
+-define (PEMKeyInKeySet, "-----BEGIN RSA PUBLIC KEY-----
+MIIBCAKCAQEAhcVgNTNQFL1Ia56bhlSPmmTZ8UhXxUO/9UNZ3uAOdh6jOpXczGJF
+LSK8SuOnm4JuiTcC5gsqf6uMgwJl+TywWVo/GC026MzfCu4NOaKmVx7p3Hs4DzXq
+aAQwv9Q6sFzF50QK+uMrdStS2Mqd/eT+dtXN2+dT9CQZfP/vHVl6UBAuUiocts5i
+elHo95FTnLMVC9TEOyCKnQ/u/335p5LEhgTvhXPPO7EV7H8cVGmAOl7Z/2qS2LwS
+6MKJaQJmMybM3YGVrz+TGJKg+5qCBOzcevsdjgyJlUuKpgzMKuxAC4lFSvuMeCD1
+ml+zRNsGrcCMyfbIa4xkIwPMvaf/ZfCzawIBEQ==
+-----END RSA PUBLIC KEY-----").
+
 %don't use test generator pattern here, otherwise we run into a funny meck issue
 %when trying to mock openid_connect_configuration module lateron:
 %https://github.com/eproxus/meck/issues/133
-load_jwk_from_config_test() ->
+load_single_jwk_from_config_test() ->
   PrivateJwk = jose_jwk:from_pem(list_to_binary(?PrivateRSAKey)),
   {_, JwkJson} = jose_jwk:to_binary(PrivateJwk),
 
@@ -43,6 +60,20 @@ load_jwk_from_config_test() ->
     meck:unload(httpc) 
   end.
 
+load_first_jwk_from_set_from_config_test() ->
+  meck:new(httpc),
+  meck:expect(httpc, request, [{["http://localhost/.well-known/openid-configuration"],
+                                {ok, { {"Version",200, "Reason"}, [], "{'jwks_uri': 'http://localhost/jwks'}"}}},
+                               {["http://localhost/jwks"],
+                                {ok, { {"Version",200, "Reason"}, [], ?KeySetJson}}}
+                              ]), 
+  try
+    JwkLoaded = load_jwk_from_config_url("http://localhost/.well-known/openid-configuration"),
+    ?assertEqual(jose_jwk:to_pem(jose_jwk:from_pem(list_to_binary(?PEMKeyInKeySet))), jose_jwk:to_pem(JwkLoaded))
+  after
+    meck:validate(httpc),
+    meck:unload(httpc) 
+  end.
 %setup() ->
 %  {ok, _} = application:ensure_all_started(inets),
 %  {ok, _} = application:ensure_all_started(ssl).

--- a/src/openid_connect_configuration.erl
+++ b/src/openid_connect_configuration.erl
@@ -58,6 +58,7 @@ Qx51AhEAz6VUgN0H5+1xwyOBtq/YEQIRANO6cLLvOFBNNaG9igT3ma0CEQClL7lR
 %when trying to mock openid_connect_configuration module lateron:
 %https://github.com/eproxus/meck/issues/133
 load_single_jwk_from_config_test() ->
+  jose:json_module(jsx),
   PrivateJwk = jose_jwk:from_pem(list_to_binary(?PrivateRSAKey)),
   {_, JwkJson} = jose_jwk:to_binary(PrivateJwk),
 

--- a/src/openid_connect_configuration.erl
+++ b/src/openid_connect_configuration.erl
@@ -15,27 +15,33 @@ load_jwk_from_config_url(ConfigurationUrl) ->
 
 % UNIT TESTS
 -ifdef(TEST).
-
-%Set of Google keys as of April 30 2016.
-%Quick and dirty approach to testing, test will fail once Google change their keys. 
--define (GoogleJwk, {jose_jwk,{jose_jwk_set,[{jose_jwk,undefined,
-                                              {jose_jwk_kty_rsa,{'RSAPublicKey',20206560680338767966113549800092864444815226395364321118810492063125077232472726130026157875619038715958927265601322339310166323162412293093211851469723779575522576466296478566790747995780410098571744471878323937448645573393799654878349438130854284659811893569111373873227493475199456374892951853689365519614169586464843255523436575946022077125295883638933581666742449113039099591769210025714286073302286758273862925269047851682708672135770642709064117060149558805245180906038583088131620476785661270604325423755298411912486722600991370383679800980249390767569969763750539090229703190168094445793264267808336779990059,
-                                                                 65537}},
-                                              #{<<"alg">> => <<"RS256">>,
-                                                <<"kid">> => <<"225038926437474586a7bcd302b06694e9d70733">>,
-                                                <<"use">> => <<"sig">>}},
-                                             {jose_jwk,undefined,
-                                              {jose_jwk_kty_rsa,{'RSAPublicKey',23057364752339592387136431039591833247815320249115920080891100289620278805852536284027635618114699005339098620472360194835114382896398817355924696759257721908424490779772199553649363807728476991453601444338567461874061798086043217971021947782206212438615786452801531112195267535798912116270886899785585331030698336380098736448360775545570371716003476414126501361187359607038623392527667825820035625377025785657841602136549202456722129978768350261691227033539821412280231303717786830482708766431502430886533945121478791201757452016728731956367280993909631426542805588267882542261363135351403804590666438077263901561561,
-                                                                 65537}},
-                                              #{<<"alg">> => <<"RS256">>,
-                                                <<"kid">> => <<"0c0e73cd83b43b1243bb05eccbf4f2908416d1d4">>,
-                                                <<"use">> => <<"sig">>}}]},
-                     undefined,#{}}).
+-define (PrivateRSAKey, "-----BEGIN RSA PRIVATE KEY-----
+MIGsAgEAAiEArrS5prfIX1AaFEzmL1wq/k3k5hiAKnJZz5ev+iIivcUCAwEAAQIg
+JJRektPENoC1FS8MuznXHlNpkYjvJ49mOfJQUSp9HIECEQDXY7Tq8V6j/HqgFSe8
+Qx51AhEAz6VUgN0H5+1xwyOBtq/YEQIRANO6cLLvOFBNNaG9igT3ma0CEQClL7lR
+6oRnlRVzT8PZOXqBAhEAssLyiaIABERKr2aGrKyE9A==
+-----END RSA PRIVATE KEY-----").
 
 load_jwk_from_config_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
-      {"should load jwk from google openid configuration", fun() -> 
-                                                               ?assertEqual(?GoogleJwk, load_jwk_from_config_url("https://accounts.google.com/.well-known/openid-configuration")) end} 
+      {"should load jwk from link in openid configuration", fun() ->
+                                                               PrivateJwk = jose_jwk:from_pem(list_to_binary(?PrivateRSAKey)),
+                                                               {_, JwkJson} = jose_jwk:to_binary(PrivateJwk),
+                                                               
+                                                               meck:new(httpc),
+                                                               meck:expect(httpc, request, [{["http://localhost/.well-known/openid-configuration"],
+                                                                                                {ok, { {"Version",200, "Reason"}, [], "{'jwks_uri': 'http://localhost/jwks'}"}}},
+                                                                                               {["http://localhost/jwks"],
+                                                                                                {ok, { {"Version",200, "Reason"}, [], binary_to_list(JwkJson)}}}
+                                                                                              ]), 
+                                                               try
+                                                                JwkLoaded = load_jwk_from_config_url("http://localhost/.well-known/openid-configuration"),
+                                                                ?assertEqual(PrivateJwk, JwkLoaded)
+                                                               after
+                                                                 meck:validate(httpc),
+                                                                 meck:unload(httpc) 
+                                                               end
+                                                           end} 
     ]}.
 
 setup() ->

--- a/test/couch_jwt_auth_tests.erl
+++ b/test/couch_jwt_auth_tests.erl
@@ -27,12 +27,6 @@ MIICWwIBAAKBgQDdlatRjRjogo3WojgGHFHYLugdUWAY9iR3fy4arWNA1KoS8kVw33cJibXr8bvwUAUp
 -----END RSA PRIVATE KEY-----").
 -define (TokenForPrivateRSAKey, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE").
 
-init_jwk_from_config_nil_test() ->
-  ?assertThrow(no_token_secret_given, init_jwk_from_config(?NilConfig)).
-
-init_jwk_conflicting_config_test() ->
-  ?assertThrow(token_provider_configuration_conflict, init_jwk_from_config(?ConflictingConfig)).
-
 decoding_using_gen_server_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
         {"load public key from openid configuration url", fun() ->
@@ -89,8 +83,8 @@ cleanup(_) ->
 
 decode_rs256_speed_when_loading_jwk_on_each_decoding_test_handler() -> 
   lists:map(fun(_) -> 
-                {JWK, Alg} = init_jwk_from_config(?RS256Config),
-                decode(?RS256Token, JWK, Alg, ?RS256Config) end, lists:seq(1, 10000)).
+                #{rs256 := #{default := JWK}} = init_jwk_from_config(?RS256Config),
+                decode(?RS256Token, JWK, <<"RS256">>, ?RS256Config) end, lists:seq(1, 10000)).
 
 decode_rs256_speed_when_using_gen_server_state_test_handler() ->
   init_jwk(?RS256Config),

--- a/test/couch_jwt_auth_tests.erl
+++ b/test/couch_jwt_auth_tests.erl
@@ -1,0 +1,137 @@
+-module(couch_jwt_auth_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+-import(couch_jwt_auth, [start_link/1, decode/1, decode/2, decode/4, validate/3]).
+-import(couch_jwt_auth, [init_jwk_from_config/1, init_jwk/1]).
+-import(couch_jwt_auth, [posix_time/1, get_userinfo_from_token/2]).
+
+-define (NilConfig, []).
+-define (EmptyConfig, [{"hs_secret",""}]).
+-define (BasicConfig, [{"hs_secret","c2VjcmV0"}]).
+-define (ConflictingConfig, [{"hs_secret","c2VjcmV0"}, {"rs_public_key", ".."}]).
+-define (BasicTokenInfo, [{"sub",<<"1234567890">>},{"name",<<"John Doe">>},{"admin",true}]).
+-define (RS256Config, [{"rs_public_key","-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDdlatRjRjogo3WojgGHFHYLugdUWAY9iR3fy4arWNA1KoS8kVw33cJibXr8bvwUAUparCwlvdbH6dvEOfou0/gCFQsHUfQrSDv+MuSUMAe8jzKE4qW+jK+xQU9a03GUnKHkkle+Q0pX/g6jXZ7r1/xAK5Do2kQ+X5xK9cipRgEKwIDAQAB
+-----END PUBLIC KEY-----"}]).
+-define (RS256TokenInfo, [{"sub",<<"1234567890">>},{"name",<<"John Doe">>},{"admin",true}]).
+-define (RS256Token, "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE").
+
+init_jwk_from_config_nil_test() ->
+  ?assertThrow(no_token_secret_given, init_jwk_from_config(?NilConfig)).
+
+init_jwk_conflicting_config_test() ->
+  ?assertThrow(hs_and_rs_configuration_conflict, init_jwk_from_config(?ConflictingConfig)).
+
+decode_malformed_empty_test() ->
+  start_link(?EmptyConfig),
+  ?assertThrow({badarg,_}, decode("", ?EmptyConfig)).
+
+decode_malformed_dots_test() ->
+  ?assertThrow({badarg,_}, decode("...", ?EmptyConfig)).
+
+decode_malformed_nosignature1_test() ->
+  ?assertThrow({badarg,_}, decode("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOmZhbHNlfQ", ?BasicConfig)).
+
+decode_malformed_nosignature2_test() ->
+  ?assertThrow(signature_not_valid, decode("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOmZhbHNlfQ.", ?BasicConfig)).
+
+decode_simple_test() ->
+  TokenInfo = ?BasicTokenInfo,
+  %compare maps here since we don't care about the order of the keys
+  ?assertEqual(maps:from_list(TokenInfo), maps:from_list(decode("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ", ?BasicConfig))).
+
+decode_unsecured_test() ->
+  ?assertThrow(signature_not_valid, decode("eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.", ?BasicConfig)).
+
+decode_rs256_test() ->
+  TokenInfo = ?RS256TokenInfo,
+  %compare maps here since we don't care about the order of the keys
+  ?assertEqual(maps:from_list(TokenInfo), maps:from_list(decode(?RS256Token, ?RS256Config))).
+
+decode_rs256_speed_when_loading_jwk_on_each_decoding_test_handler() -> 
+  lists:map(fun(_) -> 
+                {JWK, Alg} = init_jwk_from_config(?RS256Config),
+                decode(?RS256Token, JWK, Alg, ?RS256Config) end, lists:seq(1, 10000)).
+
+decode_rs256_speed_when_loading_jwk_on_each_decoding_test_() ->
+  {timeout, 20, fun decode_rs256_speed_when_loading_jwk_on_each_decoding_test_handler/0}.
+
+decode_rs256_speed_when_loading_jwk_on_each_decoding_parallel_test_() ->
+  {inparallel, [{timeout, 20, fun decode_rs256_speed_when_loading_jwk_on_each_decoding_test_handler/0}, 
+                {timeout, 20, fun decode_rs256_speed_when_loading_jwk_on_each_decoding_test_handler/0},
+                {timeout, 20, fun decode_rs256_speed_when_loading_jwk_on_each_decoding_test_handler/0}]}.
+
+decode_rs256_speed_when_using_gen_server_state_test_handler() ->
+  init_jwk(?RS256Config),
+  lists:map(fun(_) -> decode(?RS256Token) end, lists:seq(1, 10000)).
+
+decode_rs256_speed_when_using_gen_server_state_test_() ->
+  {timeout, 20, fun decode_rs256_speed_when_using_gen_server_state_test_handler/0}.
+
+decode_rs256_speed_when_using_gen_server_state_parallel_test_() ->
+  {inparallel, [{timeout, 20, fun decode_rs256_speed_when_using_gen_server_state_test_handler/0}, 
+                {timeout, 20, fun decode_rs256_speed_when_using_gen_server_state_test_handler/0}, 
+                {timeout, 20, fun decode_rs256_speed_when_using_gen_server_state_test_handler/0}]}.
+
+validate_simple_test() ->
+  TokenInfo = ?BasicTokenInfo,
+  ?assertEqual(TokenInfo, validate(TokenInfo, 1000, ?EmptyConfig)).
+
+validate_exp_nbf_test() ->
+  TokenInfo = lists:append([?BasicTokenInfo,[{"exp",2000}, {"nbf",900}]]),
+  ?assertEqual(TokenInfo, validate(TokenInfo, 1000, ?EmptyConfig)).
+
+validate_exp_rejected_test() ->
+  TokenInfo = lists:append([?BasicTokenInfo,[{"exp",2000}]]),
+  ?assertThrow(token_rejected, validate(TokenInfo, 3000, ?EmptyConfig)).
+
+validate_nbf_rejected_test() ->
+  TokenInfo = lists:append([?BasicTokenInfo,[{"nbf",2000}, {"exp",3000}]]),
+  ?assertThrow(token_rejected, validate(TokenInfo, 1000, ?EmptyConfig)).
+
+validate_aud1_rejected_test() ->
+  TokenInfo = lists:append([?BasicTokenInfo,[{"aud",<<"123">>}]]),
+  Config = lists:append([?EmptyConfig, [{"validated_claims", "aud"}, {"validate_claim_aud", "[\"456\"]"}]]),
+  ?assertThrow(token_rejected, validate(TokenInfo, 1000, Config)).
+
+validate_aud2_rejected_test() ->
+  TokenInfo = lists:append([?BasicTokenInfo,[{"aud",[<<"123">>,<<"234">>]}]]),
+  Config = lists:append([?EmptyConfig, [{"validated_claims", "aud"}, {"validate_claim_aud", "[\"456\"]"}]]),
+  ?assertThrow(token_rejected, validate(TokenInfo, 1000, Config)).
+
+validate_aud_pass_test() ->
+  TokenInfo = lists:append([?BasicTokenInfo,[{"aud",[<<"123">>,<<"234">>]}]]),
+  Config = lists:append([?EmptyConfig, [{"validated_claims", "aud"}, {"validate_claim_aud", "[\"123\",\"456\"]"}]]),
+  ?assertEqual(TokenInfo, validate(TokenInfo, 1000, Config)).
+
+validate_claims_pass_test() ->
+  TokenInfo = lists:append([?BasicTokenInfo,[{"aud",<<"123">>}, {"iss",<<"abc">>}]]),
+  Config = lists:append([?EmptyConfig, [{"validated_claims", "aud,iss"}, {"validate_claim_aud", "[\"123\"]"},{"validate_claim_iss", "[\"abc\"]"}]]),
+  ?assertEqual(TokenInfo, validate(TokenInfo, 1000, Config)).
+
+posix_time1_test() ->
+  ?assertEqual(31536000, posix_time({{1971,1,1}, {0,0,0}})).
+
+posix_time2_test() ->
+  ?assertEqual(31536001, posix_time({{1971,1,1}, {0,0,1}})).
+
+get_userinfo_from_token_default_test() ->
+  TokenInfo = ?BasicTokenInfo,
+  {UserName, Roles} = get_userinfo_from_token(TokenInfo, ?EmptyConfig),
+  ?assertEqual([], Roles),
+  ?assertEqual(<<"1234567890">>, UserName).
+
+get_userinfo_from_token_configured_test() ->
+  TokenInfo = ?BasicTokenInfo,
+  Config = lists:append([?EmptyConfig, [{"username_claim", "name"}]]),
+  {UserName, Roles} = get_userinfo_from_token(TokenInfo, Config),
+  ?assertEqual([], Roles),
+  ?assertEqual(<<"John Doe">>, UserName).
+
+% user context is created with null username if username claim is not found from token
+get_userinfo_from_token_name_not_found_test() ->
+  TokenInfo = lists:append([?BasicTokenInfo,[{"roles",[<<"123">>]}]]),
+  Config = lists:append([?EmptyConfig, [{"username_claim", "doesntexist"}]]),
+  {UserName, Roles} = get_userinfo_from_token(TokenInfo, Config),
+  ?assertEqual([<<"123">>], Roles),
+  ?assertEqual(null, UserName).

--- a/test/couch_jwt_auth_tests.erl
+++ b/test/couch_jwt_auth_tests.erl
@@ -30,10 +30,10 @@ MIICWwIBAAKBgQDdlatRjRjogo3WojgGHFHYLugdUWAY9iR3fy4arWNA1KoS8kVw33cJibXr8bvwUAUp
 decoding_using_gen_server_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
         {"load public key from openid configuration url", fun() ->
-                                                              PublicKey = jose_jwk:to_public(jose_jwk:from_pem(list_to_binary(?PrivateRSAKey))),
+                                                              PublicKey = [jose_jwk:to_public(jose_jwk:from_pem(list_to_binary(?PrivateRSAKey)))],
                                                               meck:new(openid_connect_configuration, [no_link]),
                                                               meck:expect(openid_connect_configuration, 
-                                                                          load_jwk_from_config_url, [{ ["http://localhost/.well-known/openid-configuration"], PublicKey}]),
+                                                                          load_jwk_set_from_config_url, [{ ["http://localhost/.well-known/openid-configuration"], PublicKey}]),
                                                               try
                                                                 init_jwk(?OpenIdConfig),
                                                                 decode(?TokenForPrivateRSAKey)


### PR DESCRIPTION
This PR enables verification of JWTs signed with the RS256 algorithm. Since `ejwt` only implements HS256 the first step was to use the JWT library `jose` instead of `ejwt`. In the second step I added the verification with the RS256 public key. The public key is configured by a new enty int he .ini file called `rs_public_key` and must be given in PEM format. I added tests also for the edge case where `hs_secret` and `rs_public_key` are set at the same time. 

Open questions:
- I changed some of the tests in order to reflect the exceptions thrown by `jose` which aren't always the same as the exceptions of `ejwt`. I don't think it's a big problem since there's a big try/catch in `jwt_authentication_handler`, but I'd like to have a confirmation on that.
- I'm not sure that including the public key in the .ini file is the best way, however at the time being it's the easiest way I've found. Is there a way for a CouchDB plugin to load another file in the file system? This way the public key could be placed in its own file. 

This is my very first pull request for CouchDB in general and in Erlang in particular, so I'd be more than happy for reviews, suggestions and possible improvements.

Thanks in advance,
Daniel
